### PR TITLE
Add missing packages grunt-lib-contrib and less

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-rsync": "~0.2.1",
     "grunt-bump": "0.0.13",
-    "grunt-contrib-compress": "~0.6.0"
+    "grunt-contrib-compress": "~0.6.0",
+    "grunt-lib-contrib": "~0.6.1",
+    "less": "~1.5.1"
   }
 }


### PR DESCRIPTION
I'm new to npm and grunt, but I think two packages are missing in the package.json file.
