### PR TITLE
Fixed fullscreen switch for certain multi-monitor setups

### DIFF
--- a/src/valiant.jquery.js
+++ b/src/valiant.jquery.js
@@ -432,7 +432,7 @@ three.js r65 or higher
         },
 
         fullscreen: function() {
-            if(!window.screenTop && !window.screenY && $(this.element).find('a.fa-expand').length > 0) {
+            if($(this.element).find('a.fa-expand').length > 0) {
                 this.resizeGL(screen.width, screen.height);
 
                 $(this.element).addClass('fullscreen');


### PR DESCRIPTION
Thanks for this project. I've been testing it and realized fullscreen doesn't work properly under this condition:

1. The current browser screen is the second screen a multi-monitor setup
2. The current browser screen's top is set up as being higher than the primary screen's top (e.g. primary screen landscape, second screen portrait)
3. OS is Windows 7 (at least; haven't tested OSX or other Windows versions)

Under this setup, the window.screenY/window.screenTop will have negative values, leading to false positives - the code will think it's fullscreen when it's not.

As a result, fullscreen works for the browser (it does switch the state), but the classes are not applied to the element. The video is never resized, being instead centered but keeping its original size.

My suggestion is to get rid of the top checks (are they really necessary?). It seems to work just as well.