### PR TITLE
An option to invert the dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The aim of this project is to provide a free, minimalist 360 degree video WebGL 
 
 There is currently no mobile support, but as Chrome and Safari mobile editions enable WebGL, this should be forwards-compatible with them.
 
-#### Usage 
+#### Usage
 
 See the [demo folder](https://github.com/flimshaw/Valiant360/tree/master/demo) or the [example](http://flimshaw.github.io/Valiant360).  Moving the mouse will pan the camera, and the scroll wheel will zoom in and out.
 
@@ -36,6 +36,7 @@ More detailed api documentation pending, for now the below explains about all yo
 	// initialize plugin, default options shown
 	$('.valiantContainer').Valiant360({
 		clickAndDrag: false,	// use click-and-drag camera controls
+		invertDrag: false,	// invert the directions of click-and-drag controls
 		flatProjection: false,	// map image to appear flat (often more distorted)
 		fov: 35, 				// initial field of view
 		hideControls: false,	// hide player controls

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ More detailed api documentation pending, for now the below explains about all yo
 	// initialize plugin, default options shown
 	$('.valiantContainer').Valiant360({
 		clickAndDrag: false,	// use click-and-drag camera controls
-		invertDrag: false,	// invert the directions of click-and-drag controls
+		invertDrag: false,    	// invert the directions of click-and-drag controls
 		flatProjection: false,	// map image to appear flat (often more distorted)
 		fov: 35, 				// initial field of view
 		hideControls: false,	// hide player controls

--- a/build/demo.html
+++ b/build/demo.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Valiant360
 Copyright (c) 2014 Charlie Hoey
 

--- a/src/valiant.jquery.js
+++ b/src/valiant.jquery.js
@@ -6,7 +6,7 @@
  * Released under the MIT license:
  *   http://www.opensource.org/licenses/mit-license.php
  *
- * Jquery plugin pattern based on https://github.com/jquery-boilerplate/jquery-patterns/blob/master/patterns/jquery.basic.plugin-boilerplate.js 
+ * Jquery plugin pattern based on https://github.com/jquery-boilerplate/jquery-patterns/blob/master/patterns/jquery.basic.plugin-boilerplate.js
  */
 
 /* REQUIREMENTS:
@@ -46,6 +46,7 @@ three.js r65 or higher
     var pluginName = "Valiant360",
         defaults = {
             clickAndDrag: false,
+            invertDrag: false,
             fov: 35,
             hideControls: false,
             lon: 0,
@@ -314,8 +315,13 @@ three.js r65 or higher
 
             if(this.options.clickAndDrag) {
                 if(this._mouseDown) {
+                  if(this.options.invertDrag){
+                    x = this._dragStart.x - event.pageX;
+                    y = this._dragStart.y - event.pageY;
+                  } else {
                     x = event.pageX - this._dragStart.x;
                     y = event.pageY - this._dragStart.y;
+                  }
                     this._dragStart.x = event.pageX;
                     this._dragStart.y = event.pageY;
                     this._lon += x;
@@ -327,7 +333,7 @@ three.js r65 or higher
                 this._lon = ( x / $(this.element).find('canvas').width() ) * 430 - 225;
                 this._lat = ( y / $(this.element).find('canvas').height() ) * -180 + 90;
             }
-        }, 
+        },
 
         onMouseWheel: function(event) {
 
@@ -370,7 +376,7 @@ three.js r65 or higher
         animate: function() {
             // set our animate function to fire next time a frame is ready
             requestAnimationFrame( this.animate.bind(this) );
-            
+
             if( this._isVideo ) {
                 if ( this._video.readyState === this._video.HAVE_ENOUGH_DATA) {
                     if(typeof(this._texture) !== "undefined" ) {
@@ -380,9 +386,9 @@ three.js r65 or higher
                             this._time = ct;
                         }
                     }
-                }                
+                }
             }
-            
+
             this.render();
         },
 


### PR DESCRIPTION
Inverting the click-and-drag options gives more of a "tablet"-like interaction, where you drag the image and it follows your finger. This is in contrast to hovering, where you expect the mouse to reveal new areas.

To solve this, I've added an option called `invertDrag`, which defaults to `false`. When set to true, it subtracts `event.pageX/Y` from `this._dragStart.x/y`, instead of the other way around. 