### PR TITLE
Fix for fov to be correctly set in defaults; add fovMin and fovMax to defaults; documentation updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ More detailed api documentation pending, for now the below explains about all yo
 		clickAndDrag: false,	// use click-and-drag camera controls
 		flatProjection: false,	// map image to appear flat (often more distorted)
 		fov: 35, 				// initial field of view
+		fovMin: 3, 				// min field of view allowed
+		fovMax: 100, 				// max field of view allowed
 		hideControls: false,	// hide player controls
 		lon: 0, 				// initial lon for camera angle
 		lat: 0, 				// initial lat for camera angle

--- a/src/valiant.jquery.js
+++ b/src/valiant.jquery.js
@@ -47,6 +47,8 @@ three.js r65 or higher
         defaults = {
             clickAndDrag: false,
             fov: 35,
+            fovMin: 3,
+            fovMax: 100,
             hideControls: false,
             lon: 0,
             lat: 0,
@@ -345,13 +347,10 @@ three.js r65 or higher
                 this._fov += event.detail * 1.0;
             }
 
-            var fovMin = 3;
-            var fovMax = 100;
-
-            if(this._fov < fovMin) {
-                this._fov = fovMin;
-            } else if(this._fov > fovMax) {
-                this._fov = fovMax;
+            if(this._fov < this.options.fovMin) {
+                this._fov = this.options.fovMin;
+            } else if(this._fov > this.options.fovMax) {
+                this._fov = this.options.fovMax;
             }
 
             this._camera.setLens(this._fov);

--- a/src/valiant.jquery.js
+++ b/src/valiant.jquery.js
@@ -127,7 +127,8 @@ three.js r65 or higher
             this._scene = new THREE.Scene();
 
             // create ThreeJS camera
-            this._camera = new THREE.PerspectiveCamera( this.options.fov, $(this.element).width() / $(this.element).height(), 0.1, 1000);
+            this._camera = new THREE.PerspectiveCamera(this._fov, $(this.element).width() / $(this.element).height(), 0.1, 1000);
+            this._camera.setLens(this._fov);
 
             // create ThreeJS renderer and append it to our object
             this._renderer = Detector.webgl? new THREE.WebGLRenderer(): new THREE.CanvasRenderer();


### PR DESCRIPTION
fov wasn't correctly being set for some reason on the THREE.PerspectiveCamera until setLens() was called in the mouse wheel event handler. This fix calls setLens directly after PerspectiveCamera creation.

Add fovMin and fovMax to defaults/passed opts object.