### PR TITLE
Fix `ReferenceError: event is not defined` error by making sure event param is passed to event cb's

### DIFF
--- a/src/valiant.jquery.js
+++ b/src/valiant.jquery.js
@@ -303,7 +303,7 @@ three.js r65 or higher
 
         },
 
-        onMouseMove: function() {
+        onMouseMove: function(event) {
             this._onPointerDownPointerX = event.clientX;
             this._onPointerDownPointerY = -event.clientY;
 
@@ -363,7 +363,7 @@ three.js r65 or higher
             this._dragStart.y = event.pageY;
         },
 
-        onMouseUp: function() {
+        onMouseUp: function(event) {
             this._mouseDown = false;
         },
 


### PR DESCRIPTION
Fix `ReferenceError: event is not defined` error by making sure event param is passed to event cb's

`ReferenceError: event is not defined` error given by Firefox 39.