### PR TITLE
Add destroy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ More detailed api documentation pending, for now the below explains about all yo
 	// load new photo file
 	$('.valiantContainer').Valiant360('loadPhoto', 'path/to/file.jpg');
 
+	// destroy Valiant360 processing/resources (however, will not remove element from the dom. That is left up to you)
+	$('.valiantContainer').Valiant360('destroy');	
+
 ```
 
 


### PR DESCRIPTION
Add destroy method which cancels animationFrame, and does cleanup on three.js scene resources.

This is important if the user is done with Valiant360 and wishes for it to be wiped from the page. Previously, even if all dom elements are removed, request animation frame continues forever and can cause performance leak!
